### PR TITLE
Docker cleanup

### DIFF
--- a/aslan_docker/Dockerfile
+++ b/aslan_docker/Dockerfile
@@ -1,135 +1,59 @@
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        pkg-config \
-        libxau-dev \
-        libxdmcp-dev \
-        libxcb1-dev \
-        libxext-dev \
-        libx11-dev
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-
-# COPY --from=nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04 \
-#   /usr/local/lib/x86_64-linux-gnu \
-#   /usr/local/lib/x86_64-linux-gnu
-
-COPY --from=nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04 \
-   /usr/share/glvnd/egl_vendor.d/10_nvidia.json \
-   /usr/share/glvnd/egl_vendor.d/10_nvidia.json
-
-# RUN echo '/usr/share/glvnd/egl_vendor.d/' >> /etc/ld.so.conf.d/glvnd.conf && \
-#     ldconfig && \
-#     echo '/usr/local/$LIB/libGL.so.1' >> /etc/ld.so.preload && \
-#     echo '/usr/local/$LIB/libEGL.so.1' >> /etc/ld.so.preload
-
-RUN apt-get update && apt-get install -y dialog apt-utils && apt-get install -y curl
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    	libglvnd0 libglvnd0:amd64 \
-    	libgl1 libgl1:amd64 \
- 	    libglx0 libglx0:amd64 \
- 	    libegl1 libegl1:amd64 \
- 	    libgles2 libgles2:amd64 && \
-         rm -rf /var/lib/apt/lists/*
-
-# COPY 10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
-
-
-# nvidia-container-runtime
-ENV NVIDIA_VISIBLE_DEVICES \
-    ${NVIDIA_VISIBLE_DEVICES:-all}
-ENV NVIDIA_DRIVER_CAPABILITIES \
-    ${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics
-
-
-RUN apt-get update && apt-get install -y \
-        software-properties-common \
-        wget curl git cmake cmake-curses-gui \
-        libboost-all-dev \
-        libflann-dev \
-        libgsl0-dev \
-        libgoogle-perftools-dev \
-        libeigen3-dev
-
-# Intall some basic GUI and sound libs
-RUN apt-get update && apt-get install -y \
-        xz-utils file locales dbus-x11 pulseaudio dmz-cursor-theme \
-        fonts-dejavu fonts-liberation hicolor-icon-theme \
-        libcanberra-gtk3-0 libcanberra-gtk-module libcanberra-gtk3-module \
-        libasound2 libgtk2.0-0 libdbus-glib-1-2 libxt6 libexif12 \
-        libgl1-mesa-glx libgl1-mesa-dri language-pack-en \
-        && update-locale LANG=en_US.UTF-8 LC_MESSAGES=POSIX
-
-# Intall some basic GUI tools
-RUN apt-get update && apt-get install -y \
-        cmake-qt-gui \
-        gnome-terminal
-
-# Intall ROS
-RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-RUN apt-get update && apt-get install -y --allow-unauthenticated ros-melodic-desktop-full
-RUN apt-get update && apt-get install -y --allow-unauthenticated python-rosdep python-rosinstall python-rosinstall-generator python-wstool build-essential python-catkin-tools
-# RUN apt-get install -y --allow-unauthenticated ros-melodic-can-msgs ros-melodic-socketcan-interface ros-melodic-catkin python-catkin-tools
-# RUN apt-get update && apt-get install -y --allow-unauthenticated ros-melodic-controller-manager ros-melodic-ros-control ros-melodic-ros-controllers ros-melodic-gazebo-ros-control ros-melodic-joystick-drivers ros-melodic-nmea-msgs ros-melodic-nmea-navsat-driver ros-melodic-sound-play ros-melodic-jsk-visualization ros-melodic-grid-map ros-melodic-gps-common
-RUN apt-get update && apt-get install -y --allow-unauthenticated libnlopt-dev freeglut3-dev qtbase5-dev libqt5opengl5-dev libssh2-1-dev libarmadillo-dev libpcap-dev libgl1-mesa-dev libglew-dev python-wxgtk3.0 software-properties-common libmosquitto-dev libyaml-cpp-dev python-flask python-requests
-
-# RUN DEBIAN_FRONTEND=noninteractive
-#RUN apt-get install -y --allow-unauthenticated lxde-core lxterminal tightvncserver
-#RUN rm -rf /var/lib/apt/lists/*
+FROM ros:melodic
 
 # Add basic user
 ENV USERNAME aslan_user
 ENV PULSE_SERVER /run/pulse/native
 RUN useradd -m $USERNAME && \
-        echo "$USERNAME:$USERNAME" | chpasswd && \
-        usermod --shell /bin/bash $USERNAME && \
-        usermod -aG sudo $USERNAME && \
-        echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
-        chmod 0440 /etc/sudoers.d/$USERNAME && \
-        # Replace 1000 with your user/group id
-        usermod  --uid 1000 $USERNAME && \
-        groupmod --gid 1000 $USERNAME
-
-# Setup .bashrc for ROS
-RUN echo "source /opt/ros/melodic/setup.bash" >> /home/$USERNAME/.bashrc && \
-        #Fix for qt and X server errors
-        echo "export QT_X11_NO_MITSHM=1" >> /home/$USERNAME/.bashrc && \
-        #Set ROS hostname to localhost
-#        echo "export ROS_HOSTNAME=localhost" >> /home/$USERNAME/.bashrc && \
-        # cd to home on login
-        echo "cd" >> /home/$USERNAME/.bashrc
+    echo "$USERNAME:$USERNAME" | chpasswd && \
+    usermod --shell /bin/bash $USERNAME && \
+    usermod -aG sudo $USERNAME && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/$USERNAME && \
+    chmod 0440 /etc/sudoers.d/$USERNAME && \
+    # Replace 1000 with your user/group id
+    usermod  --uid 1000 $USERNAME && \
+    groupmod --gid 1000 $USERNAME
 
 # Change user
 USER aslan_user
 
-RUN sudo rosdep init \
-        && rosdep update \
-        && echo "source /opt/ros/melodic/setup.bash" >> ~/.bashrc
+RUN cd && mkdir /home/$USERNAME/Aslan
+COPY --chown=aslan_user ./src /home/$USERNAME/Aslan/src
+
+# Install all dependencies with rosdep
+RUN bash -c 'sudo apt-get update \
+    && rosdep update \
+    && cd ~/Aslan \
+    && rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO \
+    && sudo rm -rf /var/lib/apt/lists/*'
+
+# Install build dependencies
+RUN bash -c 'sudo apt-get update \
+    && sudo apt-get install -y \
+       python-catkin-tools \
+    && sudo rm -rf /var/lib/apt/lists/*'
 
 # Install Aslan
-RUN cd && mkdir /home/$USERNAME/Aslan
-COPY --chown=aslan_user ./ /home/$USERNAME/Aslan/
-RUN /bin/bash -c 'source /opt/ros/melodic/setup.bash; cd /home/$USERNAME/Aslan; rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO; catkin init; catkin build'
-RUN echo "source /home/$USERNAME/Aslan/devel/setup.bash" >> /home/$USERNAME/.bashrc
-
-# Setting
-ENV LANG="en_US.UTF-8"
-RUN echo "export LANG=\"en_US.UTF-8\"" >> /home/$USERNAME/.bashrc
+RUN bash -c 'source /opt/ros/melodic/setup.bash \
+    && cd ~/Aslan \
+    && catkin init \
+    && catkin build'
 
 # Install dev tools
-RUN sudo apt-get -y --allow-unauthenticated install vim tmux iproute2 usbutils
-RUN sudo apt-get -y --allow-unauthenticated update && sudo apt-get install -y --allow-unauthenticated gconf2
-# # Change Terminal Color
+RUN sudo apt-get update \
+    && sudo apt-get install -y \
+       gnome-terminal \
+       dbus-x11 \
+       vim \
+       tmux \
+       iproute2 \
+       usbutils \
+       gconf2 \
+    && sudo rm -rf /var/lib/apt/lists/*
+
+# Change Terminal Color
 RUN gconftool-2 --set "/apps/gnome-terminal/profiles/Default/use_theme_background" --type bool false
 RUN gconftool-2 --set "/apps/gnome-terminal/profiles/Default/use_theme_colors" --type bool false
 RUN gconftool-2 --set "/apps/gnome-terminal/profiles/Default/background_color" --type string "#000000"
 
-LABEL com.nvidia.volumes.needed="nvidia_driver"
-ENV PATH /usr/local/nvidia/bin:${PATH}
-ENV LD_LIBRARY_PATH /usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
-
-# Default CMD
-CMD ["/bin/bash"]
+COPY run /home/$USERNAME/Aslan/run
+WORKDIR /home/$USERNAME

--- a/aslan_docker/build.bash
+++ b/aslan_docker/build.bash
@@ -1,14 +1,17 @@
 #!/bin/bash
 echo "Script executed from: ${PWD}"
 
-BASEDIR=$(dirname $0)
+BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 echo "Script location: ${BASEDIR}"
 
-cd $BASEDIR
-cp -ar ../src ./src
-cp ../run ./run
+# Go to Aslan root directory
+pushd $(dirname $BASEDIR)
 
-sudo docker build -t aslan_docker .
+# Ensure latest version of Melodic base image is available
+docker pull ros:melodic
 
-rm -r src
-rm run
+# Build Docker image
+docker build -t aslan_docker -f aslan_docker/Dockerfile .
+
+# Go back to where we came from
+popd

--- a/aslan_docker/run.bash
+++ b/aslan_docker/run.bash
@@ -1,20 +1,19 @@
 #!/bin/bash
 
-XSOCK=/tmp/.X11-unix
-XAUTH=$HOME/.Xauthority
-
-VOLUMES="--volume=$XSOCK:$XSOCK:rw
-         --volume=$XAUTH:$XAUTH:rw"
-
-nvidia-docker run \
+docker run \
     -it --rm \
     --name aslan_container \
-    $VOLUMES \
-    --env="XAUTHORITY=${XAUTH}" \
-    --env="DISPLAY=${DISPLAY}" \
+    --privileged \
+    --net=host \
     -u aslan_user \
-    --privileged -v /dev/bus/usb:/dev/bus/usb \
+    --gpus all \
+    --env DISPLAY \
+    --env NVIDIA_VISIBLE_DEVICES=all \
+    --env NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics,display \
+    --env LD_LIBRARY_PATH=/usr/local/nvidia/lib64 \
+    -v /dev/dri:/dev/dri \
+    -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -v /dev/bus/usb:/dev/bus/usb \
     -v /dev/input:/dev/input \
     -v /lib/modules:/lib/modules \
-    --net=host \
     projaslan/aslan:melodic

--- a/src/aslan_tools/aslan_gui/package.xml
+++ b/src/aslan_tools/aslan_gui/package.xml
@@ -16,6 +16,8 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>aslan_msgs</exec_depend>
+  <exec_depend>python-psutil</exec_depend>
+  <exec_depend>rqt_graph</exec_depend>
 
   <export>
   </export>


### PR DESCRIPTION
While playing with Aslan over the weekend thought I'd give it a go to clean up the Dockerfile and surrounding scripts.

The biggest changes are:

* Build and run the image expecting a 'modern' version of Docker and nvidia-docker. Since Docker 19.03 (released July 2019, both Ubuntu 18.04 and 20.04 provide 20.x) Nvidia support is better integrated with Docker. Using the NVIDIA Container Toolkit (new name for `nvidia-docker2`) you don't have to jump through all the hoops anymore and can just use `docker run --gpus all`.
* Use official `ros:melodic` image as base, which was made possible by the above.

That plus some cleanup has reduced the image size by ~750 MB. There are several apt packages I did not include here, expecting that what is needed has been declared as a dependency in a package.xml and rosdep, though maybe there are some that you know should still be there. I tested the Gazebo simulation + Rviz + rqt_graph.